### PR TITLE
Signup employeeid passport

### DIFF
--- a/api/tests/signup/benz-signup-employee-id.test.ts
+++ b/api/tests/signup/benz-signup-employee-id.test.ts
@@ -1,0 +1,232 @@
+import { test, expect } from '@playwright/test'
+
+const endpoints = {
+  signupEmployeeId:
+    'https://apiv2-staging.salary-hero.com/api/v3/public/account/signup/employee-id',
+  verifySignupEmployeeIdAddPhone:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/employee-id/add-phone?verification_method=otp&action=request',
+  verifySignupEmployeeIdAddPhoneVerify:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/employee-id/add-phone?verification_method=otp&action=verify',
+  signupFirebase:
+    'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  secureFirebaseToken:
+    'https://securetoken.googleapis.com/v1/token?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  verifyPin:
+    'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/pincode/create',
+  userProfile:
+    'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile',
+  userLogout:
+    'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/logout',
+}
+
+const employeeData = {
+  employee_id: 'benzpassport01',
+  identity: 'A260422',
+  company_id: 1288,
+  phone: '0881001995',
+  otp: '199119',
+  firstName: 'Benz',
+  pinCode: '000000',
+}
+
+const appVersion = '5.4.1'
+
+test.describe('Signup by Employee ID', () => {
+  test('signup with valid employee id and passport number', async ({
+    request,
+  }) => {
+    // 1. Input Employee ID and Passport Number
+    const signupEmployeeIdResponse = await request.post(
+      endpoints.signupEmployeeId,
+      {
+        data: {
+          employee_id: employeeData.employee_id,
+          identity: employeeData.identity,
+          company_id: employeeData.company_id,
+        },
+      }
+    )
+
+    const signupEmployeeIdResponseBody = await signupEmployeeIdResponse.json()
+    // console.log('signupEmployeeIdResponseBody: ', signupEmployeeIdResponseBody)
+
+    expect(signupEmployeeIdResponseBody.is_signup).toBe(false)
+    expect(
+      typeof signupEmployeeIdResponseBody.verification_info.auth_challenge
+    ).toBe('string')
+
+    const authChallenge =
+      signupEmployeeIdResponseBody.verification_info.auth_challenge
+
+    // 2. Input Phone Number
+    const verifyAddPhoneResponse = await request.post(
+      endpoints.verifySignupEmployeeIdAddPhone,
+      {
+        data: {
+          phone: employeeData.phone,
+          auth_challenge: authChallenge,
+        },
+      }
+    )
+
+    const verifyAddPhoneResponseBody = await verifyAddPhoneResponse.json()
+    // console.log('verifyAddPhoneResponseBody: ', verifyAddPhoneResponseBody)
+
+    expect(typeof verifyAddPhoneResponseBody.verification.ref_code).toBe(
+      'string'
+    )
+
+    const refCode = verifyAddPhoneResponseBody.verification.ref_code
+
+    // 3. Verify Phone Number - Employee ID Signup
+    const verifyEmployeeIdSignupResponse = await request.post(
+      endpoints.verifySignupEmployeeIdAddPhoneVerify,
+      {
+        data: {
+          phone: employeeData.phone,
+          auth_challenge: authChallenge,
+          verification: {
+            ref_code: refCode,
+            code: employeeData.otp,
+          },
+        },
+      }
+    )
+
+    const verifyEmployeeIdSignupResponseBody =
+      await verifyEmployeeIdSignupResponse.json()
+    // console.log('verifyEmployeeIdSignupResponseBody: ', verifyEmployeeIdSignupResponseBody)
+
+    expect(verifyEmployeeIdSignupResponseBody.verification.token).not.toBeNull()
+    expect(
+      verifyEmployeeIdSignupResponseBody.verification.profile.first_name
+    ).toBe(employeeData.firstName)
+    expect(verifyEmployeeIdSignupResponseBody.verification.profile.phone).toBe(
+      employeeData.phone
+    )
+
+    const firebaseToken = verifyEmployeeIdSignupResponseBody.verification.token
+
+    // 4. Signup Firebase
+    const firebaseAuthResponse = await request.post(endpoints.signupFirebase, {
+      data: {
+        token: firebaseToken,
+        returnSecureToken: true,
+      },
+    })
+
+    const firebaseResponseBody = await firebaseAuthResponse.json()
+    // console.log('firebaseResponseBody Body: ', firebaseResponseBody)
+
+    expect(firebaseResponseBody.kind).toBe(
+      'identitytoolkit#VerifyCustomTokenResponse'
+    )
+    expect(typeof firebaseResponseBody.idToken).toBe('string')
+    expect(typeof firebaseResponseBody.refreshToken).toBe('string')
+    expect(firebaseResponseBody.expiresIn).toBe('3600')
+    expect(firebaseResponseBody.isNewUser).toBe(false)
+
+    const firebaseRefreshToken = firebaseResponseBody.refreshToken
+
+    // 5. Token Firebase Before PIN Code Verify
+    const secureTokenBeforePinResponse = await request.post(
+      endpoints.secureFirebaseToken,
+      {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseRefreshToken,
+        },
+      }
+    )
+
+    const secureTokenBeforePinResponseBody =
+      await secureTokenBeforePinResponse.json()
+    console.log(
+      'secureTokenBeforePinResponseBody Body: ',
+      secureTokenBeforePinResponseBody
+    )
+
+    expect(typeof secureTokenBeforePinResponseBody.access_token).toBe('string')
+    expect(secureTokenBeforePinResponseBody.expires_in).toBe('3600')
+    expect(secureTokenBeforePinResponseBody.token_type).toBe('Bearer')
+    expect(typeof secureTokenBeforePinResponseBody.refresh_token).toBe('string')
+    expect(typeof secureTokenBeforePinResponseBody.id_token).toBe('string')
+    expect(typeof secureTokenBeforePinResponseBody.user_id).toBe('string')
+    expect(typeof secureTokenBeforePinResponseBody.project_id).toBe('string')
+
+    const idTokenBeforeVerifyPin = secureTokenBeforePinResponseBody.id_token
+
+    // 6. Verify PIN Code
+    const verifyPinResponse = await request.post(endpoints.verifyPin, {
+      headers: {
+        Authorization: `Bearer ${idTokenBeforeVerifyPin}`,
+        'x-app-version': '5.4.1',
+      },
+      data: {
+        pincode: employeeData.pinCode,
+      },
+    })
+
+    const verifyPinResponseBody = await verifyPinResponse.json()
+    console.log('verifyPinResponseBody Body: ', verifyPinResponseBody)
+
+    expect(verifyPinResponseBody.message).toBe('Create PIN successfully')
+
+    // 7. Token Firebase After PIN Code Verify
+    const secureTokenAfterPinResponse = await request.post(
+      endpoints.secureFirebaseToken,
+      {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseRefreshToken,
+        },
+      }
+    )
+
+    const secureTokenAfterPinResponseBody =
+      await secureTokenAfterPinResponse.json()
+    console.log(
+      'secureTokenAfterPinResponseBody Body: ',
+      secureTokenAfterPinResponseBody
+    )
+
+    expect(typeof secureTokenAfterPinResponseBody.access_token).toBe('string')
+    expect(secureTokenAfterPinResponseBody.expires_in).toBe('3600')
+    expect(secureTokenAfterPinResponseBody.token_type).toBe('Bearer')
+    expect(typeof secureTokenAfterPinResponseBody.refresh_token).toBe('string')
+    expect(typeof secureTokenAfterPinResponseBody.id_token).toBe('string')
+    expect(typeof secureTokenAfterPinResponseBody.user_id).toBe('string')
+    expect(typeof secureTokenAfterPinResponseBody.project_id).toBe('string')
+
+    const idTokenAfterVerifyPin = secureTokenAfterPinResponseBody.id_token
+
+    // 8. Get User Profile After Successfully Signup
+    const userProfileResponse = await request.get(endpoints.userProfile, {
+      headers: {
+        Authorization: `Bearer ${idTokenAfterVerifyPin}`,
+        'x-app-version': appVersion,
+      },
+    })
+
+    const userProfileResponseBody = await userProfileResponse.json()
+    console.log('userProfileResponseBody Body: ', userProfileResponseBody)
+
+    expect(userProfileResponseBody.profile.first_name).toBe(
+      employeeData.firstName
+    )
+    expect(userProfileResponseBody.profile.phone).toBe(employeeData.phone)
+
+    // 9. Logout User
+    const logoutResponse = await request.post(endpoints.userLogout, {
+      headers: {
+        Authorization: `Bearer ${idTokenAfterVerifyPin}`,
+        'x-app-version': appVersion,
+      },
+    })
+
+    const logoutResponseBody = await logoutResponse.json()
+    console.log('logoutResponseBody Body: ', logoutResponseBody)
+
+    expect(logoutResponseBody.message).toBe('Logout successfully')
+  })
+})

--- a/api/tests/signup/benz-signup-phone.test.ts
+++ b/api/tests/signup/benz-signup-phone.test.ts
@@ -118,7 +118,7 @@ test.describe('Signup by Phone', () => {
 
     expect(verifyPinResponseBody.message).toBe('Create PIN successfully');
 
-    // 6. Token Firebase Before PIN Code Verify
+    // 6. Token Firebase After PIN Code Verify
     const secureTokenAfterPinResponse = await request.post(endpoints.secureFirebaseToken,{
       data: {
         grant_type: 'refresh_token',

--- a/api/tests/signup/benz-signup-phone.test.ts
+++ b/api/tests/signup/benz-signup-phone.test.ts
@@ -1,0 +1,69 @@
+import { test, expect } from '@playwright/test'
+
+const endpoints = {
+  signupPhone:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone',
+  verifyPhone:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify',
+  signupFirebase:
+    'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+}
+
+const employeeData = {
+  phone: '0881001994',
+  otp: '199119',
+  firstName: 'Benz',
+}
+
+test.describe('Signup by Phone', () => {
+  test('signup with valid phone number', async ({ request }) => {
+    // 1. Input Phone Number
+    const response = await request.post(endpoints.signupPhone, {
+      data: {
+        phone: employeeData.phone,
+      },
+    })
+
+    const responseBody = await response.json()
+    expect(responseBody.is_signup).toBe(false)
+    expect(responseBody.next_state).toBe('signup.phone.verify')
+    expect(typeof responseBody.verification_info.ref_code).toBe('string')
+
+    const refCode = responseBody.verification_info.ref_code
+
+    // 2. Verify Phone Signup
+    const verifyResponse = await request.post(endpoints.verifyPhone, {
+      data: {
+        phone: employeeData.phone,
+        ref_code: refCode,
+        code: employeeData.otp,
+      },
+    })
+
+    const verifyResponseBody = await verifyResponse.json()
+    console.log('verifyResponseBody Body: ', verifyResponseBody)
+
+    expect(verifyResponseBody.is_signup).toBe(true)
+    expect(verifyResponseBody.next_state).toBe('user.profile')
+    expect(verifyResponseBody.verification_info.token).not.toBeNull()
+    expect(verifyResponseBody.verification_info.profile.first_name).toBe(
+      employeeData.firstName
+    )
+    expect(verifyResponseBody.verification_info.profile.phone).toBe(
+      employeeData.phone
+    )
+
+    const firebaseToken = verifyResponseBody.verification_info.token
+
+    // 3. Signup Firebase
+    const firebaseResponse = await request.post(endpoints.signupFirebase, {
+      data: {
+        token: firebaseToken,
+        returnSecureToken: true,
+      },
+    })
+
+    const firebaseResponseBody = await firebaseResponse.json()
+    console.log('firebaseResponseBody Body: ', firebaseResponseBody)
+  })
+})

--- a/api/tests/signup/benz-signup-phone.test.ts
+++ b/api/tests/signup/benz-signup-phone.test.ts
@@ -7,13 +7,20 @@ const endpoints = {
     'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify',
   signupFirebase:
     'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  secureFirebaseToken: 'https://securetoken.googleapis.com/v1/token?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  verifyPin: 'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/pincode/create',
+  userProfile: 'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile',
+  userLogout: 'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/logout'
 }
 
 const employeeData = {
   phone: '0881001994',
   otp: '199119',
   firstName: 'Benz',
+  pinCode: '000000'
 }
+
+const appVersion = '5.4.1'
 
 test.describe('Signup by Phone', () => {
   test('signup with valid phone number', async ({ request }) => {
@@ -41,7 +48,7 @@ test.describe('Signup by Phone', () => {
     })
 
     const verifyResponseBody = await verifyResponse.json()
-    console.log('verifyResponseBody Body: ', verifyResponseBody)
+    // console.log('verifyResponseBody Body: ', verifyResponseBody)
 
     expect(verifyResponseBody.is_signup).toBe(true)
     expect(verifyResponseBody.next_state).toBe('user.profile')
@@ -56,14 +63,108 @@ test.describe('Signup by Phone', () => {
     const firebaseToken = verifyResponseBody.verification_info.token
 
     // 3. Signup Firebase
-    const firebaseResponse = await request.post(endpoints.signupFirebase, {
+    const firebaseAuthResponse = await request.post(endpoints.signupFirebase, {
       data: {
         token: firebaseToken,
         returnSecureToken: true,
       },
     })
 
-    const firebaseResponseBody = await firebaseResponse.json()
-    console.log('firebaseResponseBody Body: ', firebaseResponseBody)
+    const firebaseResponseBody = await firebaseAuthResponse.json()
+    // console.log('firebaseResponseBody Body: ', firebaseResponseBody)
+
+    expect(firebaseResponseBody.kind).toBe('identitytoolkit#VerifyCustomTokenResponse');
+    expect(typeof firebaseResponseBody.idToken).toBe('string');
+    expect(typeof firebaseResponseBody.refreshToken).toBe('string');
+    expect(firebaseResponseBody.expiresIn).toBe('3600');
+    expect(firebaseResponseBody.isNewUser).toBe(false);
+
+    const firebaseRefreshToken = firebaseResponseBody.refreshToken;
+
+    // 4. Token Firebase Before PIN Code Verify
+    const secureTokenBeforePinResponse = await request.post(endpoints.secureFirebaseToken,{
+      data: {
+        grant_type: 'refresh_token',
+        refresh_token: firebaseRefreshToken
+      }
+    })
+
+    const secureTokenBeforePinResponseBody = await secureTokenBeforePinResponse.json();
+    console.log('secureTokenBeforePinResponseBody Body: ', secureTokenBeforePinResponseBody)
+
+    expect(typeof secureTokenBeforePinResponseBody.access_token).toBe('string');
+    expect(secureTokenBeforePinResponseBody.expires_in).toBe('3600');
+    expect(secureTokenBeforePinResponseBody.token_type).toBe('Bearer');
+    expect(typeof secureTokenBeforePinResponseBody.refresh_token).toBe('string');
+    expect(typeof secureTokenBeforePinResponseBody.id_token).toBe('string');
+    expect(typeof secureTokenBeforePinResponseBody.user_id).toBe('string');
+    expect(typeof secureTokenBeforePinResponseBody.project_id).toBe('string');
+
+    const idTokenBeforeVerifyPin = secureTokenBeforePinResponseBody.id_token;
+
+    // 5. Verify PIN Code
+    const verifyPinResponse = await request.post(endpoints.verifyPin, {
+      headers: {
+        Authorization: `Bearer ${idTokenBeforeVerifyPin}`,
+        'x-app-version': '5.4.1'
+      },
+      data: {
+        pincode: employeeData.pinCode
+      }
+    })
+
+    const verifyPinResponseBody = await verifyPinResponse.json();
+    console.log('verifyPinResponseBody Body: ', verifyPinResponseBody);
+
+    expect(verifyPinResponseBody.message).toBe('Create PIN successfully');
+
+    // 6. Token Firebase Before PIN Code Verify
+    const secureTokenAfterPinResponse = await request.post(endpoints.secureFirebaseToken,{
+      data: {
+        grant_type: 'refresh_token',
+        refresh_token: firebaseRefreshToken
+      }
+    })
+
+    const secureTokenAfterPinResponseBody = await secureTokenAfterPinResponse.json();
+    console.log('secureTokenAfterPinResponseBody Body: ', secureTokenAfterPinResponseBody)
+
+    expect(typeof secureTokenAfterPinResponseBody.access_token).toBe('string');
+    expect(secureTokenAfterPinResponseBody.expires_in).toBe('3600');
+    expect(secureTokenAfterPinResponseBody.token_type).toBe('Bearer');
+    expect(typeof secureTokenAfterPinResponseBody.refresh_token).toBe('string');
+    expect(typeof secureTokenAfterPinResponseBody.id_token).toBe('string');
+    expect(typeof secureTokenAfterPinResponseBody.user_id).toBe('string');
+    expect(typeof secureTokenAfterPinResponseBody.project_id).toBe('string');
+
+    const idTokenAfterVerifyPin = secureTokenAfterPinResponseBody.id_token;
+
+    // 7. Get User Profile After Successfully Signup
+    const userProfileResponse = await request.get(endpoints.userProfile, {
+      headers: {
+        Authorization: `Bearer ${idTokenAfterVerifyPin}`,
+        'x-app-version': appVersion
+      }
+    })
+
+    const userProfileResponseBody = await userProfileResponse.json();
+    console.log('userProfileResponseBody Body: ', userProfileResponseBody);
+
+    expect(userProfileResponseBody.profile.first_name).toBe(employeeData.firstName);
+    expect(userProfileResponseBody.profile.phone).toBe(employeeData.phone);
+
+    // 8. Logout User
+    const logoutResponse = await request.post(endpoints.userLogout, {
+      headers: {
+        Authorization: `Bearer ${idTokenAfterVerifyPin}`,
+        'x-app-version': appVersion
+      }
+    })
+
+    const logoutResponseBody = await logoutResponse.json();
+    console.log('logoutResponseBody Body: ', logoutResponseBody);
+
+    expect(logoutResponseBody.message).toBe('Logout successfully');
+
   })
 })

--- a/api/tests/signup/jer-signup.test.ts
+++ b/api/tests/signup/jer-signup.test.ts
@@ -5,11 +5,27 @@ const testEndpoint = {
     'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone',
   verifyPhoneSignup:
     'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify',
+
+  verifyFirebase:
+    'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+
+  VerifyTokenFirebase:
+    'https://securetoken.googleapis.com/v1/token?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+
+  createPinCode:
+    'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/pincode/create',
+
+  VerifyAfterTokenFirebase:
+    'https://securetoken.googleapis.com/v1/token?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+
+  getProfile:
+    'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile',
 }
 
 const testData = {
   phone: '0881000052',
   otp: '199119',
+  pinCode: '000000',
 }
 test.describe('Phone Signup', () => {
   test('Signup by phone', async ({ request }) => {
@@ -42,5 +58,67 @@ test.describe('Phone Signup', () => {
     expect(verifyResponseBody.next_state).toBe('user.profile')
     expect(verifyResponseBody.verification_info.token).not.toBeNull()
     expect(verifyResponseBody.company_id).not.toBeNull()
+
+    // Signup Firebase
+    const firebaseResponse = await request.post(testEndpoint.verifyFirebase, {
+      data: {
+        token: verifyResponseBody.verification_info.token,
+        returnSecureToken: true,
+      },
+    })
+    const firebaseResponseBody = await firebaseResponse.json()
+    console.log('firebaseResponseBody', firebaseResponseBody)
+
+    expect(firebaseResponseBody.idToken).not.toBeNull()
+
+    // Token Firebase before PIN code verify
+    const tokenFirebaseResponse = await request.post(
+      testEndpoint.VerifyTokenFirebase,
+      {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseResponseBody.refreshToken,
+        },
+      }
+    )
+
+    const tokenFirebaseResponseBody = await tokenFirebaseResponse.json()
+    console.log('tokenFirebaseResponseBody', tokenFirebaseResponseBody)
+
+    expect(tokenFirebaseResponseBody.id_token).not.toBeNull()
+
+    // Create PIN code
+    const createPinResponse = await request.post(testEndpoint.createPinCode, {
+      headers: {
+        Authorization: `Bearer ${tokenFirebaseResponseBody.id_token}`,
+        'x-app-version': '4.7.0',
+      },
+      data: {
+        pincode: testData.pinCode,
+      },
+    })
+    const createPinResponseBody = await createPinResponse.json()
+    console.log('createPinResponseBody', createPinResponseBody)
+
+    expect(createPinResponseBody.message).toBe('Create PIN successfully')
+
+    //Token Firebase after PIN code verify
+    const verifyPinTokenResponse = await request.post(
+      testEndpoint.VerifyAfterTokenFirebase,
+      {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseResponseBody.refreshToken,
+        },
+      }
+    )
+
+    const verifyPinTokenResponseBody = await verifyPinTokenResponse.json()
+    console.log('verifyPinTokenResponseBody', verifyPinTokenResponseBody)
+
+    expect(verifyPinTokenResponseBody.idToken).not.toBeNull()
+
+    // Get Profile
+    const getProfileResponse = await request.get(testEndpoint.getProfile, {})
   })
 })

--- a/api/tests/signup/jer-signup.test.ts
+++ b/api/tests/signup/jer-signup.test.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test'
+
+const testEndpoint = {
+  phoneSignup:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone',
+  verifyPhoneSignup:
+    'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify',
+}
+
+const testData = {
+  phone: '0881000052',
+  otp: '199119',
+}
+test.describe('Phone Signup', () => {
+  test('Signup by phone', async ({ request }) => {
+    //API endpoint
+    const response = await request.post(testEndpoint.phoneSignup, {
+      data: {
+        phone: testData.phone,
+      },
+    })
+
+    const responseBody = await response.json()
+    expect(responseBody.is_signup).toBe(false)
+    //expect(responseBody.is_otp_sent).toBe(true);
+    expect(responseBody.next_state).toBe('signup.phone.verify')
+    expect(responseBody.verification_info.ref_code).toBe('salary-hero-bypass')
+
+    //Verify Phone Signup
+    const refCode = responseBody.verification_info.ref_code
+    const verifyResponse = await request.post(testEndpoint.verifyPhoneSignup, {
+      data: {
+        phone: testData.phone,
+        code: testData.otp,
+        ref_code: refCode,
+      },
+    })
+    const verifyResponseBody = await verifyResponse.json()
+    console.log('verifyResponseBody', verifyResponseBody)
+
+    expect(verifyResponseBody.is_signup).toBe(true)
+    expect(verifyResponseBody.next_state).toBe('user.profile')
+    expect(verifyResponseBody.verification_info.token).not.toBeNull()
+    expect(verifyResponseBody.company_id).not.toBeNull()
+  })
+})

--- a/api/tests/signup/tao-signup-phone.test.ts
+++ b/api/tests/signup/tao-signup-phone.test.ts
@@ -2,45 +2,141 @@ import { test, expect } from '@playwright/test';
 
 const endpoints = {
   signupPhone: 'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone',
-  verifyPhone: 'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify'
+  verifyPhone: 'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify',
+  firebaseAuthentication: 'https://identitytoolkit.googleapis.com/v1/accounts:signInWithCustomToken?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  firebaseToken: 'https://securetoken.googleapis.com/v1/token?key=AIzaSyBeV5kfq740yW7LLhz_W2fPalGmd34gSXk',
+  createPin: 'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile/pincode/create',
+  getUserProfile: 'https://apiv2-staging.salary-hero.com/api/v1/user/account/profile'
 }
 
 const employeeData = {
   phone: '0881000051',
   otp: '199119',
+  pinCode: '000000',
+  firstName: 'Tao',
+  lastName: 'Phone Signup'
 }
+
+const appVersion = '5.4.1'
+
 
 test.describe('Signup by Phone', () => {
   test('signup with valid phone number', async({ request }) => {
+    let refCode = '';
+    let tokenBeforeAuth = '';
+    let firebaseRefreshToken = '';
+    let idTokenBeforeCreatePin = '';
+    let idTokenAfterCreatePin = '';
 
-    // 1. Input Phone number
-    const response = await request.post(endpoints.signupPhone, {
-      data: {
-        phone: employeeData.phone
-      }
+    test.step('Step 1: Input Phone number', async () => {
+      const response = await request.post(endpoints.signupPhone, {
+        data: {
+          phone: employeeData.phone
+        }
+      })
+
+      const responseBody = await response.json();
+      expect(responseBody.is_signup).toBe(false);
+      expect(responseBody.next_state).toBe('signup.phone.verify');
+      expect(typeof responseBody.verification_info.ref_code).toBe('string');
+
+      refCode = responseBody.verification_info.ref_code;
     })
 
-    const responseBody = await response.json();
-    expect(responseBody.is_signup).toBe(false);
-    expect(responseBody.next_state).toBe('signup.phone.verify');
-    expect(typeof responseBody.verification_info.ref_code).toBe('string');
+    test.step('Step 2: Verify Phone Signup', async () => {
+      const verifyResponse = await request.post(endpoints.verifyPhone, {
+        data: {
+          phone: employeeData.phone,
+          ref_code: refCode,
+          code: employeeData.otp
+        }
+      })
 
-    const refCode = responseBody.verification_info.ref_code;
+      const verifyResponseBody = await verifyResponse.json();
+      expect(verifyResponseBody.is_signup).toBe(true)
+      expect(verifyResponseBody.next_state).toBe('user.profile')
+      expect(verifyResponseBody.verification_info.token).not.toBeNull()
+      expect(typeof verifyResponseBody.verification_info.token).toBe('string')
+      expect(verifyResponseBody.verification_info.profile.first_name).toBe('Tao')
 
-    // 2. Verify Phone Signup
-    const verifyResponse = await request.post(endpoints.verifyPhone, {
-      data: {
-        phone: employeeData.phone,
-        ref_code: refCode,
-        code: employeeData.otp
-      }
+      tokenBeforeAuth = verifyResponseBody.verification_info.token;
     })
 
-    const verifyResponseBody = await verifyResponse.json();
-    expect(verifyResponseBody.is_signup).toBe(true)
-    expect(verifyResponseBody.next_state).toBe('user.profile')
-    expect(verifyResponseBody.verification_info.token).not.toBeNull()
-    expect(typeof verifyResponseBody.verification_info.token).toBe('string')
-    expect(verifyResponseBody.verification_info.profile.first_name).toBe('Tao')
+    test.step('Step 3: Signup Firebase', async () => {
+      // 3. Signup Firebase
+      const firebaseAuthResponse = await request.post(endpoints.firebaseAuthentication, {
+        data: {
+          token: tokenBeforeAuth,
+          returnSecureToken: true
+        }
+      })
+
+      const firebaseAuthResponseBody = await firebaseAuthResponse.json();
+      expect(firebaseAuthResponseBody.kind).toBe('identitytoolkit#VerifyCustomTokenResponse')
+      expect(typeof firebaseAuthResponseBody.idToken).toBe('string')
+      expect(typeof firebaseAuthResponseBody.refreshToken).toBe('string')
+      expect(firebaseAuthResponseBody.expiresIn).toBe('3600')
+      expect(firebaseAuthResponseBody.isNewUser).toBe(false)
+
+      firebaseRefreshToken = firebaseAuthResponseBody.refreshToken
+    })
+
+    test.step('Step 4: Token Firebase Before PIN code verify', async () => {
+      const firebaseTokenBeforePinCodeResponse = await request.post(endpoints.firebaseToken, {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseRefreshToken
+        }
+      })
+      
+      const firebaseTokenBeforePinCodeResponseBody = await firebaseTokenBeforePinCodeResponse.json()
+      expect(typeof firebaseTokenBeforePinCodeResponseBody.access_token).toBe('string')
+      expect(typeof firebaseTokenBeforePinCodeResponseBody.id_token).toBe('string')
+
+      idTokenBeforeCreatePin = firebaseTokenBeforePinCodeResponseBody.id_token
+    })
+
+    test.step('Step 5: Create PIN code', async () => {
+      const createPinCodeResponse = await request.post(endpoints.createPin, {
+        headers: {
+          'Authorization': `Bearer ${idTokenBeforeCreatePin}`,
+          'x-app-version': appVersion
+        },
+        data: {
+          pincode: employeeData.pinCode
+        }
+      })
+
+      const createPinCodeResponseBody = await createPinCodeResponse.json()
+      expect(createPinCodeResponseBody.message).toBe('Create PIN successfully')
+    })
+
+    test.step('Step 6: Token Firebase After PIN code verify', async () => {
+      const firebaseTokenAfterPinCodeResponse = await request.post(endpoints.firebaseToken, {
+        data: {
+          grant_type: 'refresh_token',
+          refresh_token: firebaseRefreshToken
+        }
+      })
+      const firebaseTokenAfterPinCodeResponseBody = await firebaseTokenAfterPinCodeResponse.json()
+      expect(typeof firebaseTokenAfterPinCodeResponseBody.access_token).toBe('string')
+      expect(typeof firebaseTokenAfterPinCodeResponseBody.id_token).toBe('string')
+      idTokenAfterCreatePin = firebaseTokenAfterPinCodeResponseBody.id_token
+    })
+
+    test.step('Step 7: Verify User Profile', async () => {
+      const getProfileResponse = await request.get(endpoints.getUserProfile, {
+        headers: {
+          'Authorization': `Bearer ${idTokenAfterCreatePin}`,
+          'x-app-version': appVersion
+        }
+      })
+
+      const getProfileResponseBody = await getProfileResponse.json()
+      expect(getProfileResponseBody.profile.first_name).toBe(employeeData.firstName)
+      expect(getProfileResponseBody.profile.last_name).toBe(employeeData.lastName)
+      expect(getProfileResponseBody.profile.phone).toBe(employeeData.phone)
+      expect(getProfileResponseBody.profile.signup_at).not.toBeNull()
+    })
   })
 })

--- a/api/tests/signup/tao-signup-phone.test.ts
+++ b/api/tests/signup/tao-signup-phone.test.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+
+const endpoints = {
+  signupPhone: 'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone',
+  verifyPhone: 'https://apiv2-staging.salary-hero.com/api/v2/public/account/signup/phone?action=verify'
+}
+
+const employeeData = {
+  phone: '0881000051',
+  otp: '199119',
+}
+
+test.describe('Signup by Phone', () => {
+  test('signup with valid phone number', async({ request }) => {
+
+    // 1. Input Phone number
+    const response = await request.post(endpoints.signupPhone, {
+      data: {
+        phone: employeeData.phone
+      }
+    })
+
+    const responseBody = await response.json();
+    expect(responseBody.is_signup).toBe(false);
+    expect(responseBody.next_state).toBe('signup.phone.verify');
+    expect(typeof responseBody.verification_info.ref_code).toBe('string');
+
+    const refCode = responseBody.verification_info.ref_code;
+
+    // 2. Verify Phone Signup
+    const verifyResponse = await request.post(endpoints.verifyPhone, {
+      data: {
+        phone: employeeData.phone,
+        ref_code: refCode,
+        code: employeeData.otp
+      }
+    })
+
+    const verifyResponseBody = await verifyResponse.json();
+    expect(verifyResponseBody.is_signup).toBe(true)
+    expect(verifyResponseBody.next_state).toBe('user.profile')
+    expect(verifyResponseBody.verification_info.token).not.toBeNull()
+    expect(typeof verifyResponseBody.verification_info.token).toBe('string')
+    expect(verifyResponseBody.verification_info.profile.first_name).toBe('Tao')
+  })
+})


### PR DESCRIPTION
This pull request adds several new Playwright test suites to cover and validate the signup flows (via phone and employee ID) for the Salary Hero API. The tests simulate the full end-to-end process, including phone/employee ID submission, OTP verification, Firebase authentication, PIN creation, user profile retrieval, and logout. Each test suite targets a different signup scenario and uses a different test user.

The most important changes are:

**New End-to-End Signup Tests:**

* Added `benz-signup-phone.test.ts` to test the entire phone-based signup flow, including phone verification, Firebase authentication, PIN creation, profile validation, and logout.
* Added `benz-signup-employee-id.test.ts` to test signup via employee ID and passport, covering all steps from employee ID submission to logout.
* Added `tao-signup-phone.test.ts` to test phone-based signup with Playwright's `test.step` for clearer step breakdown and additional profile field checks.
* Added `jer-signup.test.ts` to test an alternative phone signup scenario, including PIN creation and profile retrieval.

**Test Coverage and Structure Improvements:**

* Each test covers the full signup journey, including API endpoint interactions, authentication token handling, and profile validation, ensuring comprehensive coverage for different user data and flows. [[1]](diffhunk://#diff-e2eb091fe1dbd224c73b760a5bfff3c06641fd9fa07867591ca2ab0b0b6e8526R1-R170) [[2]](diffhunk://#diff-e9483cf2351c231a4243b0a5a1003d2c8b84d1674f1b166d1217f71d2d1ad3b1R1-R232) [[3]](diffhunk://#diff-432e15e7c45576789ec62c96304f02b1a6bbd6dcb8f41ac8a40dc24d5f116cb1R1-R142) [[4]](diffhunk://#diff-3e5121767a473f3cb8dc240daa43cd869c897fc3d019e5cffdca3014f2767b7fR1-R124)
* The `tao-signup-phone.test.ts` uses Playwright's `test.step` feature for improved readability and maintainability of test logic.